### PR TITLE
feat/#5 - add Root controller for status testing

### DIFF
--- a/data-service/src/main/java/com/training/controller/RootController.java
+++ b/data-service/src/main/java/com/training/controller/RootController.java
@@ -1,0 +1,16 @@
+package com.training.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class RootController {
+
+  private final static String STATUS_MESSAGE = "Data Service is up and running";
+
+  @GetMapping
+  public ResponseEntity<String> getStatus() {
+    return ResponseEntity.ofNullable(STATUS_MESSAGE);
+  }
+}

--- a/data-service/src/test/java/com/training/controller/RootControllerTest.java
+++ b/data-service/src/test/java/com/training/controller/RootControllerTest.java
@@ -1,0 +1,31 @@
+package com.training.controller;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.junit.jupiter.web.SpringJUnitWebConfig;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@SpringJUnitWebConfig
+@WebMvcTest(RootController.class)
+class RootControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Test
+  void shouldGetStatus() throws Exception {
+    // Given
+    String statusUrl = "/api";
+    String statusMessage = "Data Service is up and running";
+
+    // When + Then
+    mockMvc.perform(MockMvcRequestBuilders
+            .get(statusUrl))
+        .andExpect(MockMvcResultMatchers.status().isOk())
+        .andExpect(MockMvcResultMatchers.jsonPath("$", Matchers.is(statusMessage)));
+  }
+}


### PR DESCRIPTION
Added RootController that returns simple status message if service is working correctly.

Status is reached when querying GET /api endpoint. Return data is "Data service is up and running".